### PR TITLE
326 bake config sparse

### DIFF
--- a/developer/bake_config.py
+++ b/developer/bake_config.py
@@ -11,11 +11,9 @@ a local path.
 
 # system imports
 from __future__ import with_statement
-import re
 import os
 import sys
 import shutil
-import datetime
 
 # add sgtk API
 this_folder = os.path.abspath(os.path.dirname(__file__))
@@ -26,12 +24,10 @@ sys.path.append(python_folder)
 from tank import LogManager
 from tank.util import filesystem
 from tank.errors import TankError
-from tank.descriptor import Descriptor, descriptor_uri_to_dict, descriptor_dict_to_uri
+from tank.descriptor import Descriptor, descriptor_uri_to_dict
 from tank.descriptor import create_descriptor, is_descriptor_version_missing
 from tank.descriptor.errors import TankDescriptorError
-from tank.bootstrap.baked_configuration import BakedConfiguration
 from tank.bootstrap import constants as bootstrap_constants
-from tank_vendor import yaml
 
 from utils import (
     caching, cache_apps, authenticate, add_authentication_options,

--- a/developer/bake_config.py
+++ b/developer/bake_config.py
@@ -1,8 +1,12 @@
-# Copyright 2018 GPL Solutions, LLC.  All rights reserved.
+# Copyright (c) 2018 Shotgun Software Inc.
 #
-# Use of this software is subject to the terms of the GPL Solutions license
-# agreement provided at the time of installation or download, or which
-# otherwise accompanies this software in either electronic or hard copy form.
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Helper script to bake a Toolkit pipeline configuration given a descriptor uri or

--- a/developer/utils/caching.py
+++ b/developer/utils/caching.py
@@ -61,9 +61,9 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root, should_skip_cac
     :param sg_connection: Shotgun connection
     :param cfg_descriptor: Config descriptor
     :param bundle_cache_root: Root where to cache payload
-    :param should_skip_caching_callable: Optional callable that will check the bundle
-        type and return `True` or `False` to indicate whether it should be cached.
-        Callable must accept a the descriptor type as a single `str` parameter and
+    :param should_skip_caching_callable: Optional callable that will check the descriptor
+        and return `True` or `False` to indicate whether it should be cached.
+        Callable must accept a single parameter, the descriptor as a `dict`, and
         return a `bool`. If `None`, the default :func:`_should_skip_caching()` will be used
     """
     # introspect the config and cache everything

--- a/developer/utils/caching.py
+++ b/developer/utils/caching.py
@@ -81,15 +81,14 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
 
         for eng in env.get_engines():
             desc = env.get_engine_descriptor_dict(eng)
-            if _should_skip_caching(desc):
-                continue
-            # resolve descriptor and clone cache into bundle cache
-            _cache_descriptor(
-                sg_connection,
-                Descriptor.ENGINE,
-                desc,
-                bundle_cache_root
-            )
+            if not _should_skip_caching(desc):
+                # resolve descriptor and clone cache into bundle cache
+                _cache_descriptor(
+                    sg_connection,
+                    Descriptor.ENGINE,
+                    desc,
+                    bundle_cache_root
+                )
 
             for app in env.get_apps(eng):
                 desc = env.get_app_descriptor_dict(eng, app)

--- a/developer/utils/caching.py
+++ b/developer/utils/caching.py
@@ -53,7 +53,7 @@ def _should_skip_caching(desc):
     return desc["type"] in ["dev", "path"]
 
 
-def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
+def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root, should_skip_caching_callable=None):
     """
     Iterates over all environments within the given configuration descriptor
     and caches all items into the bundle cache root.
@@ -61,10 +61,20 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
     :param sg_connection: Shotgun connection
     :param cfg_descriptor: Config descriptor
     :param bundle_cache_root: Root where to cache payload
+    :param should_skip_caching_callable: Optional callable that will check the bundle
+        type and return `True` or `False` to indicate whether it should be cached.
+        Callable must accept a the descriptor type as a single `str` parameter and
+        return a `bool`. If `None`, the default :func:`_should_skip_caching()` will be used
     """
     # introspect the config and cache everything
     logger.info("Introspecting environments...")
     env_path = os.path.join(cfg_descriptor.get_path(), "env")
+
+    # set the function to call when checking whether to cache the bundle
+    if should_skip_caching_callable:
+        _skip_caching = should_skip_caching_callable
+    else:
+        _skip_caching = _should_skip_caching
 
     # find all environment files
     env_filenames = []
@@ -81,7 +91,7 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
 
         for eng in env.get_engines():
             desc = env.get_engine_descriptor_dict(eng)
-            if not _should_skip_caching(desc):
+            if not _skip_caching(desc):
                 # resolve descriptor and clone cache into bundle cache
                 _cache_descriptor(
                     sg_connection,
@@ -92,7 +102,7 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
 
             for app in env.get_apps(eng):
                 desc = env.get_app_descriptor_dict(eng, app)
-                if _should_skip_caching(desc):
+                if _skip_caching(desc):
                     continue
                 # resolve descriptor and clone cache into bundle cache
                 _cache_descriptor(
@@ -104,7 +114,7 @@ def cache_apps(sg_connection, cfg_descriptor, bundle_cache_root):
 
         for framework in env.get_frameworks():
             desc = env.get_framework_descriptor_dict(framework)
-            if _should_skip_caching(desc):
+            if _skip_caching(desc):
                 continue
             _cache_descriptor(
                 sg_connection,


### PR DESCRIPTION
Adds a --sparse option that will skip caching app_store bundles to keep baked configs smaller. 

Fixes a bug in tk-core that would skip checking if an engine's apps needed to be cached if the parent engine was skipped.